### PR TITLE
Working example of action cable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'rspec'
+  gem 'poltergeist'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,13 +50,14 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    cliver (0.3.2)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.12.1)
+    coffee-script-source (1.12.2)
     concurrent-ruby (1.0.2)
     cucumber (2.4.0)
       builder (>= 2.1.2)
@@ -111,7 +112,11 @@ GEM
     nio4r (1.2.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-    public_suffix (2.0.4)
+    poltergeist (1.12.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
+    public_suffix (2.0.5)
     puma (3.6.2)
     rack (2.0.1)
     rack-test (0.6.3)
@@ -212,6 +217,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  poltergeist
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
   rspec
@@ -229,4 +235,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/app/assets/javascripts/channels/events.js
+++ b/app/assets/javascripts/channels/events.js
@@ -1,0 +1,16 @@
+App.events = App.cable.subscriptions.create("EventsChannel", {
+  connected: function() {
+    // Called when the subscription is ready for use on the server
+    console.log("connected");
+  },
+
+  disconnected: function() {
+    // Called when the subscription has been terminated by the server
+    console.log("disconnected");
+  },
+
+  received: function(data) {
+    // Called when there's incoming data on the websocket for this channel
+    console.log("received". data);
+  }
+});

--- a/app/assets/javascripts/channels/events.js
+++ b/app/assets/javascripts/channels/events.js
@@ -12,6 +12,6 @@ App.events = App.cable.subscriptions.create("EventsChannel", {
   received: function(event) {
     // Called when there's incoming data on the websocket for this channel
     console.log("received", event);
-    $('body').append("<p>" + JSON.stringify(event) + "</p>");
+    $('#live').text(event.live? "event live" : "event not live");
   }
 });

--- a/app/assets/javascripts/channels/events.js
+++ b/app/assets/javascripts/channels/events.js
@@ -9,8 +9,9 @@ App.events = App.cable.subscriptions.create("EventsChannel", {
     console.log("disconnected");
   },
 
-  received: function(data) {
+  received: function(event) {
     // Called when there's incoming data on the websocket for this channel
-    console.log("received". data);
+    console.log("received", event);
+    $('body').append("<p>" + JSON.stringify(event) + "</p>");
   }
 });

--- a/app/assets/javascripts/events.js
+++ b/app/assets/javascripts/events.js
@@ -1,6 +1,0 @@
-//= require cable
-//= require_tree
-
-this.App = {};
-
-App.cable = ActionCable.createConsumer();

--- a/app/channels/application_cable/events_channel.rb
+++ b/app/channels/application_cable/events_channel.rb
@@ -1,5 +1,0 @@
-class EventsChannel < ApplicationCable::Channel
-  def subscribed
-    stream_from 'events'
-  end
-end

--- a/app/channels/events_channel.rb
+++ b/app/channels/events_channel.rb
@@ -1,0 +1,10 @@
+# Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
+class EventsChannel < ApplicationCable::Channel
+  def subscribed
+    # stream_from "some_channel"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/channels/events_channel.rb
+++ b/app/channels/events_channel.rb
@@ -2,6 +2,7 @@
 class EventsChannel < ApplicationCable::Channel
   def subscribed
     # stream_from "some_channel"
+    stream_from "events"
   end
 
   def unsubscribed

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,2 +1,5 @@
 class Event < ApplicationRecord
+  after_update do |event|
+    ActionCable.server.broadcast 'events', event
+  end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -22,11 +22,13 @@
 
 <p>
   <strong>Live:</strong>
-  <% if @event.live %>
-    event live
-  <% else %>
-    event not live
-  <% end%>
+  <span id="live">
+    <% if @event.live %>
+      event live
+    <% else %>
+      event not live
+    <% end%>
+  </span>
 </p>
 
 <%= link_to 'Edit', edit_event_path(@event) %> |

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Required to test action cable.
+  # See http://stackoverflow.com/questions/35897189/capybara-not-working-with-action-cable
+  config.action_cable.disable_request_forgery_protection = true
 end

--- a/features/joining_an_event.feature
+++ b/features/joining_an_event.feature
@@ -10,27 +10,9 @@ Feature: Joining the Event
   Background:
     Given an event exists
 
+  @javascript
   Scenario: see event status
     Given I visit the page for an event
     Then I should see "event not live"
     When the event goes live
-#    And I visit the page for an event
     Then I should see "event live"
-
-# ============================
-
-# Then(/I should see "(.*)"/) do |text|
-#   expect(page).to have_contents text
-# end
-
-# ============================
-
-
-# feature 'joining the event' do
-
-#   scenario 'join' do
-#     visit '/events'
-#     expect(page).to have_contents "event not live"
-#   end
-
-# end

--- a/features/step_definitions/joining_steps.rb
+++ b/features/step_definitions/joining_steps.rb
@@ -13,7 +13,4 @@ end
 When(/^the event goes live$/) do
   @event.live = true
   @event.save
-  ActionCable.server.broadcast 'events',
-                               event: @event.live,
-                               user: 'sam'
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,15 @@
 # files.
 
 require 'cucumber/rails'
+require 'capybara/poltergeist'
+
+# Require to enable javascript in tests
+# See https://github.com/teampoltergeist/poltergeist
+Capybara.javascript_driver = :poltergeist
+
+# Required to test action cable.
+# See http://stackoverflow.com/questions/35897189/capybara-not-working-with-action-cable
+Capybara.server = :puma
 
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any
@@ -55,4 +64,3 @@ end
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
-


### PR DESCRIPTION
In this example, clients receive live updates of the `Event` model and display something both in the browser's console and the web page.

It can be tested manually using two web browsers.
