### PR TITLE
Migration to fix incorrect column name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EventManager
+# EventManager App
 A system for managing events and hangout participation - microservice API and basic UI
 
 ```gherkin

--- a/db/migrate/20170424020035_change_events_datetime_col_to_date.rb
+++ b/db/migrate/20170424020035_change_events_datetime_col_to_date.rb
@@ -1,0 +1,5 @@
+class ChangeEventsDatetimeColToDate < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :events, :datetime, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161215165914) do
+ActiveRecord::Schema.define(version: 20170424020035) do
 
   create_table "events", force: :cascade do |t|
     t.string   "name"
     t.date     "date"
-    t.time     "time"
     t.time     "duration"
     t.boolean  "live"
     t.datetime "created_at", null: false


### PR DESCRIPTION
There is currently no column named `datetime` in the schema.
@mattlindsey do we want the `time` column back in?  If so, we  should do _another_ migration.