### PR TITLE
Fix Issue #39 - Changed duration type and date name in Events table

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -72,6 +72,6 @@ class EventsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def event_params
-      params.require(:event).permit(:name, :date, :end, :duration, :live)
+      params.require(:event).permit(:name, :start_date, :end, :duration, :live)
     end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,8 +1,8 @@
 class Event < ApplicationRecord
-  scope :today,    -> { where(date: Date.today)}
-  scope :past_now, -> { where('date >= ?', Time.now)}
-  scope :latest,   -> { order('date DESC') }
-  scope :by_start_date, -> (start_date) { where('date >= ?', start_date)}
+  scope :today,    -> { where(start_date: Date.today)}
+  scope :past_now, -> { where('start_date >= ?', Time.now)}
+  scope :latest,   -> { order('start_date DESC') }
+  scope :by_start_date, -> (start_date) { where('start_date >= ?', start_date)}
 
   after_update do |event|
     ActionCable.server.broadcast 'events', event

--- a/app/views/events/_event.json.jbuilder
+++ b/app/views/events/_event.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! event, :id, :name, :date, :duration, :live, :created_at, :updated_at
+json.extract! event, :id, :name, :start_date, :duration, :live, :created_at, :updated_at
 json.url event_url(event, format: :json)

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="field">
     <%= f.label :date %>
-    <%= f.date_select :date %>
+    <%= f.date_select :start_date %>
   </div>
 
   <div class="field">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -24,7 +24,7 @@
     <% @events.each do |event| %>
       <tr>
         <td><%= event.name %></td>
-        <td><%= event.date %></td>
+        <td><%= event.start_date %></td>
         <td><%= event.duration %></td>
         <td><%= event.live %></td>
         <td><%= link_to 'Show', event %></td>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -7,7 +7,7 @@
 
 <p>
   <strong>Date:</strong>
-  <%= @event.date %>
+  <%= @event.start_date %>
 </p>
 
 <p>

--- a/db/migrate/20170717212424_rename_event_date_to_start_date.rb
+++ b/db/migrate/20170717212424_rename_event_date_to_start_date.rb
@@ -1,0 +1,5 @@
+class RenameEventDateToStartDate < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :events, :date, :start_date
+  end
+end

--- a/db/migrate/20170717214127_change_duration_type_in_events.rb
+++ b/db/migrate/20170717214127_change_duration_type_in_events.rb
@@ -1,0 +1,5 @@
+class ChangeDurationTypeInEvents < ActiveRecord::Migration[5.1]
+  def change
+    change_column :events, :duration, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161215165914) do
+ActiveRecord::Schema.define(version: 20170717214127) do
 
   create_table "events", force: :cascade do |t|
-    t.string   "name"
-    t.date     "date"
-    t.time     "time"
-    t.time     "duration"
-    t.boolean  "live"
+    t.string "name"
+    t.date "start_date"
+    t.time "time"
+    t.integer "duration"
+    t.boolean "live"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/features/seeing_date_ranged_events.feature
+++ b/features/seeing_date_ranged_events.feature
@@ -5,10 +5,10 @@ Feature: Date Range Events
 
   Background:
     Given following events exist:
-      | name       | date                    | duration | live  |
-      | Standup1   | 2014/02/03 07:00:00 UTC | 150      | false |
-      | Standup2   | 2014/02/07 10:00:00 UTC | 60       | true  |
-      | Standup3   | 2014/02/09 07:00:00 UTC | 150      | false |
+      | name       | start_date                    | duration | live  |
+      | Standup1   | 2014/02/03 07:00:00 UTC       | 150      | false |
+      | Standup2   | 2014/02/07 10:00:00 UTC       | 60       | true  |
+      | Standup3   | 2014/02/09 07:00:00 UTC       | 150      | false |
     Given the date is "2014/02/01 10:15:00 UTC"
 
   Scenario: see upcoming events

--- a/features/seeing_upcoming_events.feature
+++ b/features/seeing_upcoming_events.feature
@@ -5,10 +5,10 @@ Feature: Upcoming Event View
 
   Background:
     Given following events exist:
-      | name       | date                    | duration | live  |
-      | Standup1   | 2014/02/03 07:00:00 UTC | 150      | false |
-      | PP Session | 2019/02/07 10:00:00 UTC | 15       | false |
-      | Standup2   | 2014/01/03 07:00:00 UTC | 150      | false |
+      | name       | start_date                    | duration | live  |
+      | Standup1   | 2014/02/03 07:00:00 UTC       | 150      | false |
+      | PP Session | 2019/02/07 10:00:00 UTC       | 15       | false |
+      | Standup2   | 2014/01/03 07:00:00 UTC       | 150      | false |
     Given the date is "2014/02/05 09:15:00 UTC"
 
   @javascript


### PR DESCRIPTION
- Changed 'duration' type to be an integer in the table 'Events'
- Changed column name 'date' to 'start_date' in the table 'Events'